### PR TITLE
Add dark mode with system theme support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { useWindowFocus } from "@/hooks/use-window-focus";
 import { useTauriEvents } from "@/hooks/useTauriEvent";
 import { useMediaList } from "@/hooks/useMediaList";
 import { useDownloadManager } from "@/hooks/useDownloadManager";
+import { useTheme } from "@/hooks/useTheme";
 
 // State
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
@@ -74,6 +75,9 @@ function debounce(callback: () => void, delay: number): () => void {
  */
 function App(): JSX.Element {
   const tauriApi = useTauriApi();
+
+  // Apply theme
+  useTheme();
 
   // Local state
   const [notificationPermission, setNotificationPermission] = useState(false);

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -39,6 +39,14 @@ import {
   maxFileSizeAtom,
   themeAtom,
   type Theme,
+  type DownloadMode,
+  type VideoQuality,
+  type MaxResolution,
+  type VideoFormat,
+  type AudioFormat,
+  type AudioQuality,
+  type DownloadRateLimit,
+  type MaxFileSize,
 } from "@/state/settings-atoms";
 import { useTauriApi } from "@/lib/TauriApiContext";
 
@@ -221,7 +229,9 @@ export function SettingsDialog({
             </Label>
             <Select
               value={downloadRateLimit}
-              onValueChange={(value) => setDownloadRateLimit(value as any)}
+              onValueChange={(value) =>
+                setDownloadRateLimit(value as DownloadRateLimit)
+              }
             >
               <SelectTrigger id="download-rate-limit" className="col-span-3">
                 <SelectValue />
@@ -245,7 +255,7 @@ export function SettingsDialog({
             </Label>
             <Select
               value={maxFileSize}
-              onValueChange={(value) => setMaxFileSize(value as any)}
+              onValueChange={(value) => setMaxFileSize(value as MaxFileSize)}
             >
               <SelectTrigger id="max-file-size" className="col-span-3">
                 <SelectValue />
@@ -270,7 +280,7 @@ export function SettingsDialog({
             </Label>
             <Select
               value={downloadMode}
-              onValueChange={(value) => setDownloadMode(value as any)}
+              onValueChange={(value) => setDownloadMode(value as DownloadMode)}
             >
               <SelectTrigger id="download-mode" className="col-span-3">
                 <SelectValue />
@@ -295,7 +305,9 @@ export function SettingsDialog({
                   </Label>
                   <Select
                     value={videoQuality}
-                    onValueChange={(value) => setVideoQuality(value as any)}
+                    onValueChange={(value) =>
+                      setVideoQuality(value as VideoQuality)
+                    }
                   >
                     <SelectTrigger id="video-quality" className="col-span-3">
                       <SelectValue />
@@ -315,7 +327,9 @@ export function SettingsDialog({
                   </Label>
                   <Select
                     value={maxResolution}
-                    onValueChange={(value) => setMaxResolution(value as any)}
+                    onValueChange={(value) =>
+                      setMaxResolution(value as MaxResolution)
+                    }
                   >
                     <SelectTrigger id="max-resolution" className="col-span-3">
                       <SelectValue />
@@ -337,7 +351,9 @@ export function SettingsDialog({
                   </Label>
                   <Select
                     value={videoFormat}
-                    onValueChange={(value) => setVideoFormat(value as any)}
+                    onValueChange={(value) =>
+                      setVideoFormat(value as VideoFormat)
+                    }
                   >
                     <SelectTrigger id="video-format" className="col-span-3">
                       <SelectValue />
@@ -365,7 +381,7 @@ export function SettingsDialog({
               </Label>
               <Select
                 value={audioFormat}
-                onValueChange={(value) => setAudioFormat(value as any)}
+                onValueChange={(value) => setAudioFormat(value as AudioFormat)}
               >
                 <SelectTrigger id="audio-format" className="col-span-3">
                   <SelectValue />
@@ -385,7 +401,9 @@ export function SettingsDialog({
               </Label>
               <Select
                 value={audioQuality}
-                onValueChange={(value) => setAudioQuality(value as any)}
+                onValueChange={(value) =>
+                  setAudioQuality(value as AudioQuality)
+                }
               >
                 <SelectTrigger id="audio-quality" className="col-span-3">
                   <SelectValue />

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -37,6 +37,7 @@ import {
   maxConcurrentDownloadsAtom,
   downloadRateLimitAtom,
   maxFileSizeAtom,
+  themeAtom,
 } from "@/state/settings-atoms";
 import { useTauriApi } from "@/lib/TauriApiContext";
 
@@ -51,6 +52,7 @@ export function SettingsDialog({
   const [alwaysOnTop, setAlwaysOnTop] = useAtom(alwaysOnTopAtom);
   const [isWayland, setIsWayland] = useState(false);
   const [outputLocation, setOutputLocation] = useAtom(downloadLocationAtom);
+  const [theme, setTheme] = useAtom(themeAtom);
 
   // Advanced settings (Phase 3.2)
   const [downloadMode, setDownloadMode] = useAtom(downloadModeAtom);
@@ -118,6 +120,25 @@ export function SettingsDialog({
         </DialogHeader>
 
         <div className="grid gap-6 py-4">
+          {/* Theme settings */}
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="theme" className="text-right">
+              Theme
+            </Label>
+            <Select value={theme} onValueChange={(value) => setTheme(value as any)}>
+              <SelectTrigger id="theme" className="col-span-3">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="system">System</SelectItem>
+                <SelectItem value="light">Light</SelectItem>
+                <SelectItem value="dark">Dark</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Separator />
+
           {/* Window settings */}
           {isWayland ? (
             <Alert variant="destructive" className="text-left">

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -38,6 +38,7 @@ import {
   downloadRateLimitAtom,
   maxFileSizeAtom,
   themeAtom,
+  type Theme,
 } from "@/state/settings-atoms";
 import { useTauriApi } from "@/lib/TauriApiContext";
 
@@ -125,7 +126,10 @@ export function SettingsDialog({
             <Label htmlFor="theme" className="text-right">
               Theme
             </Label>
-            <Select value={theme} onValueChange={(value) => setTheme(value as any)}>
+            <Select
+              value={theme}
+              onValueChange={(value) => setTheme(value as Theme)}
+            >
               <SelectTrigger id="theme" className="col-span-3">
                 <SelectValue />
               </SelectTrigger>

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -1,0 +1,133 @@
+import { renderHook } from "@testing-library/react";
+import { useTheme } from "./useTheme";
+import { useAtomValue } from "jotai";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// Mock jotai
+vi.mock("jotai", () => ({
+  useAtomValue: vi.fn(),
+}));
+
+describe("useTheme", () => {
+  let matchMediaMock: any;
+  let listeners: any = {};
+
+  beforeEach(() => {
+    // Reset document class list
+    document.documentElement.classList.remove("dark");
+
+    // Mock matchMedia
+    listeners = {};
+    matchMediaMock = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn((event, callback) => {
+        listeners[event] = callback;
+      }),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    window.matchMedia = matchMediaMock;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies system theme on mount (dark)", () => {
+    // Mock system dark mode
+    matchMediaMock.mockImplementation((query: string) => ({
+      matches: true, // System is dark
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+
+    // Mock theme atom value as 'system'
+    (useAtomValue as any).mockReturnValue("system");
+
+    renderHook(() => useTheme());
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("applies system theme on mount (light)", () => {
+    // Mock system light mode
+    matchMediaMock.mockImplementation((query: string) => ({
+      matches: false, // System is light
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+
+    (useAtomValue as any).mockReturnValue("system");
+
+    renderHook(() => useTheme());
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("toggles dark class when theme changes to dark", () => {
+    (useAtomValue as any).mockReturnValue("dark");
+
+    renderHook(() => useTheme());
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("toggles dark class when theme changes to light", () => {
+    // First set it to dark
+    document.documentElement.classList.add("dark");
+    (useAtomValue as any).mockReturnValue("light");
+
+    renderHook(() => useTheme());
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("responds to system preference changes", () => {
+    // Initial state: system is light
+    matchMediaMock.mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn((event, callback) => {
+        listeners[event] = callback;
+      }),
+      removeEventListener: vi.fn(),
+    }));
+
+    (useAtomValue as any).mockReturnValue("system");
+
+    renderHook(() => useTheme());
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    // Change system preference to dark
+    matchMediaMock.mockImplementation((query: string) => ({
+      matches: true, // Now it is dark
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+
+    // Trigger change listener
+    if (listeners["change"]) {
+      listeners["change"]();
+    }
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("handles missing matchMedia gracefully", () => {
+    // Remove matchMedia
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: undefined,
+    });
+
+    (useAtomValue as any).mockReturnValue("system");
+
+    // Should not throw
+    expect(() => renderHook(() => useTheme())).not.toThrow();
+  });
+});

--- a/src/hooks/useTheme.test.ts
+++ b/src/hooks/useTheme.test.ts
@@ -130,4 +130,21 @@ describe("useTheme", () => {
     // Should not throw
     expect(() => renderHook(() => useTheme())).not.toThrow();
   });
+
+  it("cleans up event listener on unmount", () => {
+    const removeEventListenerSpy = vi.fn();
+    matchMediaMock.mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: removeEventListenerSpy,
+    }));
+
+    (useAtomValue as any).mockReturnValue("system");
+
+    const { unmount } = renderHook(() => useTheme());
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalled();
+  });
 });

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -25,13 +25,16 @@ export function useTheme(): void {
         let effectiveTheme: "light" | "dark" = "light";
 
         if (theme === "system") {
-          // Check system preference with error handling
-          if (!window.matchMedia) return;
-
-          const prefersDark = window.matchMedia(
-            "(prefers-color-scheme: dark)",
-          ).matches;
-          effectiveTheme = prefersDark ? "dark" : "light";
+          // Handle system preference with fallback for browsers without matchMedia
+          if (!window.matchMedia) {
+            // Fallback to light theme if matchMedia unavailable
+            effectiveTheme = "light";
+          } else {
+            const prefersDark = window.matchMedia(
+              "(prefers-color-scheme: dark)",
+            ).matches;
+            effectiveTheme = prefersDark ? "dark" : "light";
+          }
         } else {
           effectiveTheme = theme;
         }

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { useAtomValue } from "jotai";
+import { themeAtom } from "@/state/settings-atoms";
+
+/**
+ * Hook to apply theme to the document based on user preference and system theme
+ * Detects system theme preference using prefers-color-scheme media query
+ */
+export function useTheme(): void {
+  const theme = useAtomValue(themeAtom);
+
+  useEffect(() => {
+    const applyTheme = () => {
+      const htmlElement = document.documentElement;
+      let effectiveTheme: "light" | "dark" = "light";
+
+      if (theme === "system") {
+        // Check system preference
+        const prefersDark = window.matchMedia(
+          "(prefers-color-scheme: dark)",
+        ).matches;
+        effectiveTheme = prefersDark ? "dark" : "light";
+      } else {
+        effectiveTheme = theme;
+      }
+
+      // Apply theme by toggling the .dark class
+      if (effectiveTheme === "dark") {
+        htmlElement.classList.add("dark");
+      } else {
+        htmlElement.classList.remove("dark");
+      }
+    };
+
+    applyTheme();
+
+    // Listen for system theme changes
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    // Handle changes (use addEventListener for better compatibility)
+    const handleChange = () => {
+      if (theme === "system") {
+        applyTheme();
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange);
+    };
+  }, [theme]);
+}

--- a/src/state/settings-atoms.ts
+++ b/src/state/settings-atoms.ts
@@ -90,3 +90,7 @@ export const maxFileSizeAtom = atomWithStorage<MaxFileSize>(
   "maxFileSize",
   "unlimited",
 );
+
+// Theme settings
+export type Theme = "system" | "light" | "dark";
+export const themeAtom = atomWithStorage<Theme>("theme", "system");


### PR DESCRIPTION
- Add theme atom with support for system/light/dark preferences
- Create useTheme hook that detects system preference and applies theme
- Add theme settings selector to SettingsDialog
- Theme persists in localStorage and defaults to system preference
- Dark mode CSS styling already configured in App.css

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Theme selector in Settings (System, Light, Dark) with persisted preference.
  * App applies the selected theme on startup, follows system preference when set to System, and updates live when system theme changes; handles non-browser environments gracefully.

* **Tests**
  * Added tests covering theme application, system fallback, dynamic system-change handling, cleanup, and behavior when matchMedia is absent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->